### PR TITLE
Added support for ST3

### DIFF
--- a/seeing_is_believing.py
+++ b/seeing_is_believing.py
@@ -1,6 +1,8 @@
 import sublime, sublime_plugin, subprocess, os, sys
 
 class SeeingIsBelieving(sublime_plugin.TextCommand):
+
+  # In python 3.3 process communication return bytes instead of strings
   def to_srt(self, seq):
     if sys.version_info[0] > 2:
       return seq.decode('utf-8')
@@ -50,11 +52,9 @@ class SeeingIsBelieving(sublime_plugin.TextCommand):
       sublime.message_dialog(self.to_srt(out[1]))
       return
 
-    replace_str = self.to_srt(out[0])
     # replace body with result, reset the selection
-    #self.view.replace(edit, region, out[0])
+    replace_str = self.to_srt(out[0])
     self.view.replace(edit, region, replace_str)
-    #self.view.replace(edit, region, str(out[0])) # not really the wanted solution
     point = self.view.text_point(row, col)
     self.view.sel().clear()
     self.view.sel().add(sublime.Region(point))


### PR DESCRIPTION
Works with st2 and st3 with my simple tests (correct and erroneous one)

``` ruby
puts "foo"
```

``` ruby
puts "foo
```

Fixes #8
