### PR TITLE
Closes #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,38 +18,34 @@ You have two options for installing the SeeingIsBelieving Plugin: using Git, or 
 
 Open your terminal application and go to your Packages directory, whose location depends on your operating system:
 
-* OS X - For Sublime Text 2 use `cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages`, and for Sublime Text 3 use `cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages`
+Sublime Text 2:
+
+* OS X - `cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages`
 * Linux - `cd ~/.Sublime\ Text 2/Packages/`
 * Windows - `cd %APPDATA%/Sublime Text 2/Packages/`
 
-After this, you need to clone this repository: `git clone git://github.com/JoshCheek/sublime-text-2-seeing-is-believing.git SeeingIsBelieving`
+Sublime Text 3:
+
+* OS X - `cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages`
+* Linux - `cd ~/.Sublime\ Text 3/Packages/`
+* Windows - `cd %APPDATA%/Sublime Text 3/Packages/`
+
+After this, you need to clone this repository: `git clone git://github.com/JoshCheek/sublime-text-2-and-3-seeing-is-believing.git SeeingIsBelieving`
 
 **Download**
 
 Click on the nice cloud icon above and download the zip file containing this plugin. Then unzip the file and move the resulting folder to your Packages directory.
 
-**Fixing Settings**
+**Customizing**
 
-You will need to update the [settings](https://github.com/JoshCheek/sublime-text-2-seeing-is-believing/blob/master/Seeing%20Is%20Believing.sublime-settings)
-that tell this plugin how to run the code. This is in your package directory.
+You can customize which Ruby to use, and how to invoke SiB in the
+[settings](https://github.com/JoshCheek/sublime-text-2-seeing-is-believing/blob/master/Seeing%20Is%20Believing.sublime-settings).
 
-If you are using **rbenv**, make sure the `ruby_command` is pointed at `~/.rbenv/shims/ruby`, or wherever you have your rbenv ruby installed,
-then edit the environment variable specifying the `RBENV_VERSION`, you can see a list of possible values with `rbenv versions`.
+In particular, you'll need to go here if it can't find your Ruby.
+In that situation, try opening a shell and running `ruby -e 'p RbConfig.ruby'`,
+its possible that what it prints is the value you need to set. You can also
+set environment variables here, and set any flags that you want passed to SiB.
 
-If you are using **rvm**, make a wrapper for sublime (instructions are in the [textmate integration](https://rvm.io/integration/textmate/) section,
-make the wrapper the same way they do for Textmate, except name it sublime instead),
-find the path with `which sublime_ruby`, and set that as the value of `ruby_command` in the settings file.
-
-If you are using **something else**, you just need to make sure that `ruby_command` points to a 1.9+ version of Ruby that has
-`seeing_is_believing` [seeing_is_believing](http://rubygems.org/gems/seeing_is_believing) installed.
-
-If you are installing on **Windows**, you will need to provide the fully qualified path to `ruby_command` using '/' rather than the Window's default '\':
-
-Example: `"ruby_command": "C:/path/to/ruby.exe"`
-
-You will also need to comment out the line containing `RBENV_VERSION`.
-
-Example: `//"RBENV_VERSION": "2.0.0-p0"`
 
 ## Usage
 

--- a/Seeing Is Believing.sublime-settings
+++ b/Seeing Is Believing.sublime-settings
@@ -1,14 +1,10 @@
 {
-  // the command to run your ruby, again this is setup for rbenv
-  // if you've installed Ruby without any managers, this would just be "ruby"
-  "ruby_command": "~/.rbenv/shims/ruby",
-
+  // If you want to run a specific Ruby from a specific location,
+  // then you can override the command it uses to invoke Ruby.
+  "ruby_command": "ruby",
 
   // environment variables to set before running
   "environment_variables": {
-    // for bootstrapping rbenv
-    // if you manage your versions differently, you'll have to figure out how your manager works
-    "RBENV_VERSION": "2.2.2p95",
     "LANG": "en_US.UTF-8"
   },
 
@@ -26,11 +22,11 @@
     // line            =>  each line is at its own alignment
     "--alignment-strategy": "chunk",
 
-    // timeout limit in seconds when evaluating source file (ex. -t 0.3 or -t 3)
     // omit for no timeout (warning, can freeze your editor up if you have an infinite loop)
-    "--timeout": 12,
+    "--timeout-seconds": 12,
 
-    // sets file encoding, equivalent to Ruby's -Kx (see `man ruby` for valid values)
-    "--encoding": "u"
+    // stops recording after this many results, which keeps it from slowing down
+    // in big loops, and resuces spam in the same way that the --line-length does
+    "--max-line-captures": 200,
   }
 }

--- a/seeing_is_believing.py
+++ b/seeing_is_believing.py
@@ -33,8 +33,6 @@ class SeeingIsBelieving(sublime_plugin.TextCommand):
     args.append(ruby_command)
     args.append('-S')
     args.append('seeing_is_believing')
-    args.append('--shebang')
-    args.append(ruby_command)
     if self.view.file_name() != None:
       args.append("--as")
       args.append(self.view.file_name())
@@ -52,8 +50,9 @@ class SeeingIsBelieving(sublime_plugin.TextCommand):
       sublime.message_dialog(self.to_srt(out[1]))
       return
 
-    # replace body with result, reset the selection
-    replace_str = self.to_srt(out[0])
+    # replace body with result, reset the selection.
+    # for more info about the "\r\n" replacement, see https://github.com/JoshCheek/sublime-text-2-and-3-seeing-is-believing/issues/20
+    replace_str = self.to_srt(out[0]).replace("\r\n", "\n")
     self.view.replace(edit, region, replace_str)
     point = self.view.text_point(row, col)
     self.view.sel().clear()


### PR DESCRIPTION
* Remove deprecated settings, update renamed ones
* Use "ruby" as the default executable, since Sublime seems to have figured out the PATH since I last looked at it. This should prevent people from having to deal with the headache of configuring it after installing it.
* Update README
* Remove the `--shebang` call since SiB is smart enough to figure that out on its own now
* Substitute CRLF with LF, to fix #20. As near as I can tell, ST uses LF internally, and only converts the line ends when the file is saved. So, SiB (correctly, I believe) printed the output with CRLF (it happens on the write to stdout, but super hard to reflect on and understand why), and when ST saw the CRLF, it ignored the CR, and only treated the LF as the line end. Thus, the CR was rendered inline and when it saved the file, it converted the LF to a CRLF, causing CRCRLF in the saved file.